### PR TITLE
feat: add multi-arch support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,14 @@ jobs:
             type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 
 WORKDIR /build
 
@@ -13,8 +16,8 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o skillserver ./cmd/skillserver
+# Build the binary for the target platform
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -installsuffix cgo -o skillserver ./cmd/skillserver
 
 # Runtime stage
 FROM alpine:latest

--- a/README.md
+++ b/README.md
@@ -37,20 +37,20 @@ SkillServer supports both **environment variables** and **command-line flags**. 
 
 ### Environment Variables
 
-| Variable | Alternative | Default | Description |
-|----------|-------------|---------|-------------|
-| `SKILLSERVER_DIR` | `SKILLS_DIR` | `./skills` | Directory to store skills |
-| `SKILLSERVER_PORT` | `PORT` | `8080` | Port for the web server |
-| `SKILLSERVER_GIT_REPOS` | `GIT_REPOS` | (empty) | Comma-separated Git repository URLs |
-| `SKILLSERVER_ENABLE_LOGGING` | (none) | `false` | Enable logging to stderr (default: false to avoid interfering with MCP stdio) |
+| Variable                     | Alternative  | Default    | Description                                                                   |
+|------------------------------|--------------|------------|-------------------------------------------------------------------------------|
+| `SKILLSERVER_DIR`            | `SKILLS_DIR` | `./skills` | Directory to store skills                                                     |
+| `SKILLSERVER_PORT`           | `PORT`       | `8080`     | Port for the web server                                                       |
+| `SKILLSERVER_GIT_REPOS`      | `GIT_REPOS`  | (empty)    | Comma-separated Git repository URLs                                           |
+| `SKILLSERVER_ENABLE_LOGGING` | (none)       | `false`    | Enable logging to stderr (default: false to avoid interfering with MCP stdio) |
 
 ### Command-Line Flags
 
-| Flag | Description |
-|------|-------------|
-| `--dir` | Directory to store skills (overrides `SKILLSERVER_DIR` or `SKILLS_DIR`) |
-| `--port` | Port for the web server (overrides `SKILLSERVER_PORT` or `PORT`) |
-| `--git-repos` | Comma-separated list of Git repository URLs (overrides `SKILLSERVER_GIT_REPOS` or `GIT_REPOS`) |
+| Flag               | Description                                                                                                                               |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `--dir`            | Directory to store skills (overrides `SKILLSERVER_DIR` or `SKILLS_DIR`)                                                                   |
+| `--port`           | Port for the web server (overrides `SKILLSERVER_PORT` or `PORT`)                                                                          |
+| `--git-repos`      | Comma-separated list of Git repository URLs (overrides `SKILLSERVER_GIT_REPOS` or `GIT_REPOS`)                                            |
 | `--enable-logging` | Enable logging to stderr (overrides `SKILLSERVER_ENABLE_LOGGING`). Default: false (disabled to avoid interfering with MCP stdio protocol) |
 
 ## Usage


### PR DESCRIPTION
Since it would be great to also have this tool on Apple silicon macBooks, multi platform build is necessary.

- ✅ Tested the changes with a dummy tag in my fork
  - https://github.com/DrackThor/skillserver/actions/runs/23835173192
- ✅ Tested the created image on my macBook, also works 

---

- .github/workflows/ci.yml: add QEMU setup for multi-arch builds, update Docker platforms
- Dockerfile: use platform-specific build, add target OS and architecture args
- README.md: align table formatting for better readability